### PR TITLE
Fix wrong color profile on some devices. Add note on how to fix NSCameraUsageDescription requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ override func viewDidLoad() {
 }
 ```
 
- Knows issues: Capturing audio requires that you provide a valid NSCameraUsageDescription (or NSMicrophoneUsageDescription?) key in the InfoPlist when you submit your app to appstoreconnect. Anyway, If you are not using the audio recorder, you can exclude the `AVCaptureSession+BaseRecorder` extension from the Target Membership and this will fix appstoreconnect asking for NSCameraUsageDescription key.
+ Knows issues: Capturing audio requires that you provide a valid NSCameraUsageDescription key in the InfoPlist when you submit your app to appstoreconnect. If you are not using the audio recorder, you can exclude the `AVCaptureSession+BaseRecorder.swift` extension from the Target Membership. Doing that fixes appstoreconnect asking for NSCameraUsageDescription key.
 
 ### Music Overlay
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ override func viewDidLoad() {
 }
 ```
 
+ Knows issues: Capturing audio requires that you provide a valid NSCameraUsageDescription (or NSMicrophoneUsageDescription?) key in the InfoPlist when you submit your app to appstoreconnect. Anyway, If you are not using the audio recorder, you can exclude the `AVCaptureSession+BaseRecorder` extension from the Target Membership and this will fix appstoreconnect asking for NSCameraUsageDescription key.
+
 ### Music Overlay
 
 Instead of capturing audio using microphone you can play music and add it to video at the same time.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ override func viewDidLoad() {
 }
 ```
 
- Knows issues: Capturing audio requires that you provide a valid NSCameraUsageDescription key in the InfoPlist when you submit your app to appstoreconnect. If you are not using the audio recorder, you can exclude the `AVCaptureSession+BaseRecorder.swift` extension from the Target Membership. Doing that fixes appstoreconnect asking for NSCameraUsageDescription key.
+ **Known issue:** Capturing audio requires that you provide a valid NSCameraUsageDescription key in the InfoPlist when you submit your app to appstoreconnect. If you are not using the audio recorder, you can exclude the `AVCaptureSession+BaseRecorder.swift` extension from the Target Membership. Doing that fixes appstoreconnect asking for NSCameraUsageDescription key.
 
 ### Music Overlay
 

--- a/Sources/Extensions/AVCaptureSession+BaseRecorder.swift
+++ b/Sources/Extensions/AVCaptureSession+BaseRecorder.swift
@@ -23,10 +23,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-/* NOTE
- You should exclude this class from the Target Membership if you don't use its functionality.
- In this way you are not required to include NSCameraUsageDescription when pushing your build to appstoreconnect
- */
 import Foundation
 import AVFoundation
 

--- a/Sources/Extensions/AVCaptureSession+BaseRecorder.swift
+++ b/Sources/Extensions/AVCaptureSession+BaseRecorder.swift
@@ -23,6 +23,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+/* NOTE
+ You should exclude this class from the Target Membership if you don't use its functionality.
+ In this way you are not required to include NSCameraUsageDescription when pushing your build to appstoreconnect
+ */
 import Foundation
 import AVFoundation
 

--- a/Sources/MediaSession/MediaSession.swift
+++ b/Sources/MediaSession/MediaSession.swift
@@ -148,7 +148,7 @@ extension MediaSession {
     var videoSettings = videoSettings
     if videoSettings.size == nil { videoSettings.size = videoInput.size }
     if videoSettings.transform == nil { videoSettings.transform = videoInput.videoTransform }
-    videoSettings.videoColorProperties = videoInput.videoColorProperties
+    //videoSettings.videoColorProperties = videoInput.videoColorProperties
 
     let audioSettingsDictionary = audioSettings?.outputSettings
       ?? audioInput?.recommendedAudioSettingsForAssetWriter(

--- a/Sources/VideoSettings.swift
+++ b/Sources/VideoSettings.swift
@@ -73,7 +73,7 @@ extension VideoSettings {
       AVVideoHeightKey: size?.height,
       AVVideoCodecKey: codec.avCodec,
       AVVideoScalingModeKey: scalingMode.avScalingMode,
-      AVVideoColorPropertiesKey: videoColorProperties,
+      //AVVideoColorPropertiesKey: videoColorProperties,
       AVVideoCompressionPropertiesKey: codec.compressionProperties
     ] as [String: Any?]).compactMapValues({ $0 })
   }


### PR DESCRIPTION
This should solve the issue of wrong colors when recording on some devices. It also includes instructions on how to solve the problem of appstoreconnect requiring NSCameraUsageDescription key.