### PR TITLE
Build fix for Swift 5.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/v-grigoriev/MulticastDelegate.git",
         "state": {
           "branch": null,
-          "revision": "19a9cc018fd22589594f7868400823b382d0cf08",
+          "revision": "d650db9f294d2ebeab9e48e1825b6a16af860a62",
           "version": "1.0.1"
         }
       }

--- a/Sources/MediaSession/MediaSessionInput.swift
+++ b/Sources/MediaSession/MediaSessionInput.swift
@@ -33,11 +33,11 @@ protocol MediaSessionInput {
 
   typealias Video = VideoMediaSessionInput
 
-  typealias SampleBufferAudio = Audio & SampleBufferInput
+  typealias SampleBufferAudio = AudioMediaSessionInput & SampleBufferInput
 
-  typealias SampleBufferVideo = Video & SampleBufferInput
+  typealias SampleBufferVideo = VideoMediaSessionInput & SampleBufferInput
 
-  typealias PixelBufferVideo = Video & BufferInput
+  typealias PixelBufferVideo = VideoMediaSessionInput & BufferInput
 
   func start()
 


### PR DESCRIPTION
PR to fix this issue: https://github.com/gorastudio-ceo/SCNRecorder/issues/46. Swift 5.7 doesn't seem to like the nested typealiases, so I unnested some of them. 