### PR TITLE
Support pause/resume video

### DIFF
--- a/Sources/Outputs/VideoOutput/VideoOutput.State.swift
+++ b/Sources/Outputs/VideoOutput/VideoOutput.State.swift
@@ -97,6 +97,13 @@ public enum VideoOutputState: Equatable {
     }
   }
 
+  var isRecording: Bool {
+    guard case .recording = self else {
+      return false
+    }
+    return true
+  }
+
   func resume(_ videoOutput: VideoOutput) -> Self {
     switch self {
 
@@ -130,8 +137,7 @@ public enum VideoOutputState: Equatable {
          .preparing:
       return .ready
 
-    case .recording(let seconds):
-      videoOutput.endSession(at: seconds)
+    case .recording:
       return .paused
 
     case .paused,

--- a/Sources/Outputs/VideoOutput/VideoOutput.State.swift
+++ b/Sources/Outputs/VideoOutput/VideoOutput.State.swift
@@ -64,8 +64,6 @@ public enum VideoOutputState: Equatable {
   case recording(time: CMTime, pause: CMTime?, resume: CMTime?)
 
   /// Recording is paused.
-  /// Not tested.
-  /// According to Apple, documentation might not work.
   case paused(time: CMTime, pause: CMTime)
 
   /// Recording is canceled.

--- a/Sources/Outputs/VideoOutput/VideoOutput.swift
+++ b/Sources/Outputs/VideoOutput/VideoOutput.swift
@@ -153,7 +153,12 @@ extension VideoOutput {
   }
 
   func appendVideo(sampleBuffer: CMSampleBuffer) throws {
-    guard videoInput.isReadyForMoreMediaData else { return }
+    guard
+      videoInput.isReadyForMoreMediaData,
+      state.isRecording
+    else {
+      return
+    }
     guard videoInput.append(sampleBuffer) else {
       if assetWriter.status == .failed { throw assetWriter.error ?? Error.unknown }
       return
@@ -175,10 +180,17 @@ extension VideoOutput {
   }
 
   func appendAudio(sampleBuffer: CMSampleBuffer) throws {
-    guard let audioInput = audioInput else { return }
-    guard audioInput.isReadyForMoreMediaData else { return }
+    guard
+      let audioInput = audioInput,
+      audioInput.isReadyForMoreMediaData,
+      state.isRecording
+    else {
+        return
+    }
     guard audioInput.append(sampleBuffer) else {
-      if assetWriter.status == .failed { throw assetWriter.error ?? Error.unknown }
+      if assetWriter.status == .failed {
+          throw assetWriter.error ?? Error.unknown
+      }
       return
     }
   }

--- a/Sources/Outputs/VideoOutput/VideoOutput.swift
+++ b/Sources/Outputs/VideoOutput/VideoOutput.swift
@@ -141,7 +141,9 @@ extension VideoOutput {
   }
 
   func append(pixelBuffer: CVPixelBuffer, withPresentationTime time: CMTime) throws {
-    guard pixelBufferAdaptor.assetWriterInput.isReadyForMoreMediaData else { return }
+    guard pixelBufferAdaptor.assetWriterInput.isReadyForMoreMediaData else {
+      return
+    }
     guard pixelBufferAdaptor.append(pixelBuffer, withPresentationTime: time) else {
       if assetWriter.status == .failed { throw assetWriter.error ?? Error.unknown }
       return
@@ -153,10 +155,7 @@ extension VideoOutput {
   }
 
   func appendVideo(sampleBuffer: CMSampleBuffer) throws {
-    guard
-      videoInput.isReadyForMoreMediaData,
-      state.isRecording
-    else {
+    guard videoInput.isReadyForMoreMediaData else {
       return
     }
     guard videoInput.append(sampleBuffer) else {
@@ -182,8 +181,7 @@ extension VideoOutput {
   func appendAudio(sampleBuffer: CMSampleBuffer) throws {
     guard
       let audioInput = audioInput,
-      audioInput.isReadyForMoreMediaData,
-      state.isRecording
+      audioInput.isReadyForMoreMediaData
     else {
         return
     }

--- a/Sources/SelfRecordable/SelfRecordable.swift
+++ b/Sources/SelfRecordable/SelfRecordable.swift
@@ -189,6 +189,14 @@ public extension SelfRecordable {
     return videoRecording
   }
 
+  func pauseVideoRecording() {
+    videoRecording?.pause()
+  }
+
+  func resumeVideoRecording() {
+    videoRecording?.resume()
+  }
+
   func finishVideoRecording(completionHandler handler: @escaping (VideoRecording.Info) -> Void) {
     videoRecording?.finish { videoRecordingInfo in
       DispatchQueue.main.async { handler(videoRecordingInfo) }


### PR DESCRIPTION
**Problem**

- The session was ended on pause method so when the video was resumed it threw an exception

**Solution**
- Don't end session on pause
- Add pause & resume times to the states so the time generated by CoreEngine can be adjusted so the video is created without any gap.

**Improvement**
- Avoid render while the video is paused: to implement it properly the framework would need a refactor so the input are paused not only the output.

**Resolves**
- Resolves #61
